### PR TITLE
[Feature]: integration of vite-plugin-lit-css for better DX

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,6 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400&family=Poppins:wght@300;400&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="./src/styles.css">
     <script type="module" src="./src/index.ts"></script>
   </head>
 

--- a/demo/src/index.ts
+++ b/demo/src/index.ts
@@ -2,7 +2,5 @@
 import '../../src/assets/elevations.css'
 import '../../src/assets/colors.css'
 
-import './styles.css'
-
 // Import components
 import '../../src/index'

--- a/demo/src/vite-env.d.ts
+++ b/demo/src/vite-env.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="vite-plugin-lit-css/client" />
 /// <reference types="vite/client" />

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import litCss from 'vite-plugin-lit-css'
+
+export default defineConfig({
+  plugins: [
+    litCss({
+      exclude: [/assets\/.*/]
+    })
+  ]
+})

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "typescript": "5.0.2",
     "vite": "4.4.0",
     "vite-plugin-dts": "3.3.1",
+    "vite-plugin-lit-css": "1.0.1",
     "vite-plugin-static-copy": "0.17.0"
   }
 }

--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -1,8 +1,8 @@
-import { PropertyValueMap, LitElement, unsafeCSS, html, css } from 'lit'
+import { PropertyValueMap, LitElement, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import { when } from 'lit/directives/when.js'
 
-import styles from './alert.css?inline'
+import styles from './alert.css'
 
 import '../button/button.js'
 
@@ -21,7 +21,7 @@ export type AlertType = 'info' | 'success' | 'warning' | 'error'
 
 @customElement('hwc-alert')
 export class HWCAlert extends LitElement {
-  static styles = css`${unsafeCSS(styles)}`
+  static styles = styles
 
   @property({ type: String }) appearance: AlertAppearance = 'filled'
 

--- a/src/button/button.ts
+++ b/src/button/button.ts
@@ -1,7 +1,7 @@
-import { PropertyValueMap, LitElement, unsafeCSS, html, css } from 'lit'
+import { PropertyValueMap, LitElement, html } from 'lit'
 import { customElement, property, query } from 'lit/decorators.js'
 
-import styles from './button.css?inline'
+import styles from './button.css'
 
 import { isValidColorFormat } from '../utils/isValidColorFormat.js'
 
@@ -20,7 +20,7 @@ export type ButtonElevation = '1' | '2' | '3' | '4' | '5';
 
 @customElement('hwc-button')
 export class HWCButton extends LitElement {
-  static styles = css`${unsafeCSS(styles)}`
+  static styles = styles
 
   // eslint-disable-next-line no-undef
   private readonly internals = this.attachInternals()

--- a/src/card/card.ts
+++ b/src/card/card.ts
@@ -1,7 +1,7 @@
-import { CSSResultGroup, LitElement, PropertyValueMap, css, html, unsafeCSS } from 'lit'
+import { CSSResultGroup, LitElement, PropertyValueMap, html } from 'lit'
 import { customElement, property, query } from 'lit/decorators.js'
 
-import styles from './card.css?inline'
+import styles from './card.css'
 
 import { isValidColorFormat } from '../utils/isValidColorFormat.js'
 
@@ -16,7 +16,7 @@ export type CardElevation = '0' | '1' | '2' | '3' | '4' | '5'
 
 @customElement('hwc-card')
 export class HWCCard extends LitElement {
-  static styles?: CSSResultGroup | undefined = css`${unsafeCSS(styles)}`
+  static styles?: CSSResultGroup | undefined = styles
 
   @query('.card__header') private $cardHeader!: HTMLElement
 

--- a/src/checkbox/checkbox.ts
+++ b/src/checkbox/checkbox.ts
@@ -1,8 +1,8 @@
-import { PropertyValueMap, css, html, unsafeCSS } from 'lit'
+import { PropertyValueMap, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import { when } from 'lit/directives/when.js'
 
-import styles from './checkbox.css?inline'
+import styles from './checkbox.css'
 
 import { isValidColorFormat } from '../utils/isValidColorFormat.js'
 import { generateHash } from '../utils/generateHash.js'
@@ -18,7 +18,7 @@ declare global {
 
 @customElement('hwc-checkbox')
 export class HWCCheckbox extends InputField {
-  static styles = css`${unsafeCSS(styles)}`
+  static styles = styles
 
   @property({ type: String }) color!: string
 

--- a/src/chip/chip.ts
+++ b/src/chip/chip.ts
@@ -1,8 +1,8 @@
-import { CSSResultGroup, LitElement, PropertyValueMap, css, html, unsafeCSS } from 'lit'
+import { CSSResultGroup, LitElement, PropertyValueMap, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import { when } from 'lit/directives/when.js'
 
-import styles from './chip.css?inline'
+import styles from './chip.css'
 
 import { isValidColorFormat } from '../utils/isValidColorFormat.js'
 
@@ -21,7 +21,7 @@ export type ChipSize = 'x-small' | 'small' | 'regular' | 'large' | 'x-large'
 
 @customElement('hwc-chip')
 export class HWCChip extends LitElement {
-  static styles?: CSSResultGroup | undefined = css`${unsafeCSS(styles)}`
+  static styles?: CSSResultGroup | undefined = styles
 
   @property({ type: String, reflect: true }) appearance: ChipAppearence = 'filled'
 

--- a/src/radio/radio.ts
+++ b/src/radio/radio.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-undef */
-import { PropertyValueMap, unsafeCSS, css, html } from 'lit'
+import { PropertyValueMap, html } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 import { when } from 'lit/directives/when.js'
 
-import styles from './radio.css?inline'
+import styles from './radio.css'
 
 import { isValidColorFormat } from '../utils/isValidColorFormat.js'
 import { generateHash } from '../utils/generateHash.js'
@@ -19,7 +19,7 @@ declare global {
 
 @customElement('hwc-radio')
 export class HWCRadio extends InputField {
-  static styles = css`${unsafeCSS(styles)}`
+  static styles = styles
 
   @property({ type: String }) value = 'on'
 

--- a/src/ripple/ripple.ts
+++ b/src/ripple/ripple.ts
@@ -1,7 +1,7 @@
-import { LitElement, PropertyValueMap, css, html, unsafeCSS } from 'lit'
+import { LitElement, PropertyValueMap, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 
-import styles from './ripple.css?inline'
+import styles from './ripple.css'
 
 import { isValidColorFormat } from '../utils/isValidColorFormat.js'
 
@@ -14,7 +14,7 @@ declare global {
 
 @customElement('hwc-ripple')
 export class HWCRipple extends LitElement {
-  static styles = css`${unsafeCSS(styles)}`
+  static styles = styles
 
   @property({ type: String }) color!: string
 

--- a/src/select/select.ts
+++ b/src/select/select.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-use-before-define */
 /* eslint-disable no-undef */
 import { customElement, property, query } from 'lit/decorators.js'
-import { PropertyValueMap, css, html, unsafeCSS } from 'lit'
+import { PropertyValueMap, html } from 'lit'
 import { when } from 'lit/directives/when.js'
 import { map } from 'lit/directives/map.js'
 
-import styles from './select.css?inline'
+import styles from './select.css'
 
 import { isValidColorFormat } from '../utils/isValidColorFormat.js'
 import { generateHash } from '../utils/generateHash.js'
@@ -26,7 +26,7 @@ declare global {
 
 @customElement('hwc-select')
 export class HWCSelect extends InputField {
-  static styles = css`${unsafeCSS(styles)}`
+  static styles = styles
 
   @query('button') protected $input!: HTMLButtonElement
 

--- a/src/text-field/text-field.ts
+++ b/src/text-field/text-field.ts
@@ -1,8 +1,8 @@
 import { customElement, property, query } from 'lit/decorators.js'
-import { PropertyValueMap, unsafeCSS, html, css } from 'lit'
+import { PropertyValueMap, html } from 'lit'
 import { when } from 'lit/directives/when.js'
 
-import styles from './text-field.css?inline'
+import styles from './text-field.css'
 
 import { TextFieldError } from '../error.js'
 
@@ -52,7 +52,7 @@ const _validateType = (value: string | null) => {
 
 @customElement('hwc-text-field')
 export class HWCTextField extends InputField {
-  static styles = css`${unsafeCSS(styles)}`
+  static styles = styles
 
   @query('.text-field__control') $control!: HTMLDivElement
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
+import litCss from 'vite-plugin-lit-css'
 import path from 'path'
 
 export default defineConfig({
@@ -38,6 +39,11 @@ export default defineConfig({
     }
   },
   plugins: [
+    // transform styles
+    litCss({
+      exclude: [/assets\/.*/]
+    }),
+
     // Generate d.ts.
     dts({
       outDir: './dist/types',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       formats: ['es']
     },
     rollupOptions: {
-      external: /lit/,
+      external: /^lit/,
       output: {
         globals: {
           lit: 'lit',


### PR DESCRIPTION
Hi! Currently, I'm developing the vite-plugin-lit-css as my free time project. Unfortunately, I do not have enough feedback :c an I think this project could be suitable for trying to adopt it.

This plugin tries to fix some problems with the lit css ecosystem, in this case, allows to remove all 
```js
css`${usafeCss(styles)}`
``` 
overload, to simply import styles as any other framework does, keeping all the power of vite css(scss, sass, etc).

PD: link to npm package https://www.npmjs.com/package/vite-plugin-lit-css